### PR TITLE
Simplify the rate limiter

### DIFF
--- a/glog_test.go
+++ b/glog_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	stdLog "log"
-	"math"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -420,7 +419,14 @@ func TestRateLimit(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
 	defer func() { SetRateLimit(time.Second, 100000) }()
-	SetRateLimit(time.Duration(math.MaxInt32)*time.Second, 1)
+
+	np := time.Now()
+	now := &np
+	timeNow = func() time.Time { return *now }
+	defer func() { timeNow = time.Now }()
+
+	const kInterval time.Duration = time.Minute
+	SetRateLimit(kInterval, 1)
 
 	okLog := "look at me"
 	Info(okLog)
@@ -444,7 +450,7 @@ func TestRateLimit(t *testing.T) {
 	}
 
 	// Reset the rate limiter
-	SetRateLimit(time.Duration(math.MaxInt32)*time.Second, 1)
+	np = np.Add(kInterval)
 	anotherLog := "hello!"
 	Info(anotherLog)
 	count = strings.Count(contents(infoLog), anotherLog)
@@ -469,7 +475,7 @@ func TestRateLimit(t *testing.T) {
 	}
 
 	// Reset the rate limiter again
-	SetRateLimit(time.Duration(math.MaxInt32)*time.Second, 1)
+	np = np.Add(kInterval)
 
 	anotherLog = "hello there again!"
 	Info(anotherLog)

--- a/ratelimiter_test.go
+++ b/ratelimiter_test.go
@@ -12,42 +12,41 @@ func TestRateLimiterLimits(t *testing.T) {
 	timeNow = func() time.Time { return *now }
 	defer func() { timeNow = time.Now }()
 
-	rl := newRateLimiter(time.Minute, 6)
-	for i := 0; i != 6; i++ {
-		if rl.shouldRateLimit() {
+	const kBurst int = 6
+	const kInterval time.Duration = time.Minute
+
+	skipped := -1
+	rl := NewRateLimiter(kInterval, kBurst, func(sk int) { skipped = sk })
+	for i := 0; i != kBurst; i++ {
+		if !rl.Allowed() {
 			t.Errorf("limits at iteration %d when it shouldn't", i)
 		}
 	}
-	if !rl.shouldRateLimit() {
+	if rl.Allowed() {
 		t.Errorf("does not limit when it should")
 	}
-	np = np.Add(time.Duration(9) * time.Second)
-	if !rl.shouldRateLimit() {
-		t.Errorf("rate limiter doesn't round interval down")
+	np = np.Add(kInterval / 2)
+	if rl.Allowed() {
+		t.Errorf("rate limiter shouldn't have advanced")
 	}
-	np = np.Add(time.Duration(2) * time.Second)
-	if rl.shouldRateLimit() {
-		t.Errorf("rate limiter didn't let up when time advanced")
-	}
-	np = np.Add(time.Duration(2) * time.Second)
-	if !rl.shouldRateLimit() {
-		t.Errorf("rate limiter should limit again")
-	}
-	np = np.Add(time.Duration(2) * time.Minute)
-	for i := 0; i != 6; i++ {
-		if rl.shouldRateLimit() {
+	np = np.Add(kInterval / 2)
+	for i := 0; i != kBurst; i++ {
+		if !rl.Allowed() {
 			t.Errorf("iteration %d shouldn't limit now", i)
 		}
 	}
-	for i := 0; i != 6; i++ {
-		if !rl.shouldRateLimit() {
+	if skipped != 2 {
+		t.Errorf("expected 2 skipped items, not %d", skipped)
+	}
+	for i := 0; i != kBurst; i++ {
+		if rl.Allowed() {
 			t.Errorf("iteration %d should limit now", i)
 		}
 	}
 }
 
 func TestInifiniteRateLimiterDoesntRateLimit(t *testing.T) {
-	rl := newInfiniteRateLimiter()
+	rl := newInfiniteRateLimiter(func(int) {})
 	wg := sync.WaitGroup{}
 	for n := 0; n != 16; n++ {
 		wg.Add(1)
@@ -55,7 +54,7 @@ func TestInifiniteRateLimiterDoesntRateLimit(t *testing.T) {
 			defer wg.Done()
 			//	can't spend TOO long running this test, but do it enough that it matters
 			for i := 0; i != 500000; i++ {
-				if rl.shouldRateLimit() {
+				if !rl.Allowed() {
 					t.Fatal("rl.shouldRateLimit() should never return true for an infinite rate limiter!")
 				}
 			}


### PR DESCRIPTION
The existing code printed that messages were lost far too often.
This was confusing, since the only throttled messages were likely
from log levels that weren't being printed anyways.

Also simplify the rate-limiter implementation.  It now is lock-free
for all checks, except when it had been throttled and an item is
allowed through after the timeout.  The new implementation is
a pure cliff, allowing through at most the burstCount number
of items within any given burstInterval.